### PR TITLE
Add test suite for iati_file_delete action with permission checks

### DIFF
--- a/ckanext/iati_generator/tests/test_actions_delete.py
+++ b/ckanext/iati_generator/tests/test_actions_delete.py
@@ -4,7 +4,7 @@ from ckan.tests import factories
 from ckan import model
 
 from ckanext.iati_generator.models.iati_files import IATIFile
-from ckanext.iati_generator.models.enums import IATIFileTypes
+from ckanext.iati_generator.tests.factories import create_iati_file
 
 
 @pytest.fixture
@@ -48,54 +48,45 @@ class TestIatiFileDeleteAction:
     def _api(self, action):  # helper
         return f"/api/3/action/{action}"
 
-    def _create_file(self, app, headers, res_id, file_type=IATIFileTypes.ORGANIZATION_MAIN_FILE.name):
-        """Creates an IATIFile via API and returns the result dict."""
-        return app.post(
-            self._api("iati_file_create"),
-            params={"resource_id": res_id, "file_type": file_type},
-            headers=headers,
-            status=200,
-        ).json["result"]
-
     # --- PERMISSIONS / OK FLOWS ------------------------------------------------
 
     def test_delete_allowed_for_sysadmin(self, app, setup_data):
-        created = self._create_file(app, setup_data.sysadmin["headers"], setup_data.res["id"])
+        created = create_iati_file(resource_id=setup_data.res["id"])
 
         # sysadmin can delete
         resp = app.post(
             self._api("iati_file_delete"),
-            params={"id": created["id"]},
+            json={"id": created.id},
             headers=setup_data.sysadmin["headers"],
             status=200,
         ).json["result"]
         assert resp["success"] is True
 
         # Confirm removed from DB
-        assert model.Session.query(IATIFile).get(created["id"]) is None
+        assert model.Session.query(IATIFile).get(created.id) is None
 
     def test_delete_allowed_for_org_admin(self, app, setup_data):
         # Create file (sysadmin) and delete as organization admin
-        created = self._create_file(app, setup_data.sysadmin["headers"], setup_data.res["id"])
+        created = create_iati_file(resource_id=setup_data.res["id"])
 
         resp = app.post(
             self._api("iati_file_delete"),
-            params={"id": created["id"]},
+            params={"id": created.id},
             headers=setup_data.user_admin["headers"],
             status=200,
         ).json["result"]
         assert resp["success"] is True
-        assert model.Session.query(IATIFile).get(created["id"]) is None
+        assert model.Session.query(IATIFile).get(created.id) is None
 
     # --- PERMISSIONS / DENIED --------------------------------------------------
 
     def test_delete_denied_for_editor_and_member(self, app, setup_data):
-        created = self._create_file(app, setup_data.sysadmin["headers"], setup_data.res["id"])
+        created = create_iati_file(resource_id=setup_data.res["id"])
 
         # editor -> 403
         app.post(
             self._api("iati_file_delete"),
-            params={"id": created["id"]},
+            params={"id": created.id},
             headers=setup_data.user_editor["headers"],
             status=403,
         )
@@ -103,13 +94,13 @@ class TestIatiFileDeleteAction:
         # member -> 403
         app.post(
             self._api("iati_file_delete"),
-            params={"id": created["id"]},
+            params={"id": created.id},
             headers=setup_data.user_member["headers"],
             status=403,
         )
 
         # Still exists
-        assert model.Session.query(IATIFile).get(created["id"]) is not None
+        assert model.Session.query(IATIFile).get(created.id) is not None
 
     def test_delete_denied_when_admin_of_other_org(self, app, setup_data):
         # Create file in a different org
@@ -119,16 +110,16 @@ class TestIatiFileDeleteAction:
             package_id=other_pkg["id"], format="CSV", url_type="upload",
             url="other.csv", name="other.csv",
         )
-        created = self._create_file(app, setup_data.sysadmin["headers"], other_res["id"])
+        created = create_iati_file(resource_id=other_res["id"])
 
         # Admin of original org cannot delete file from another org
         app.post(
             self._api("iati_file_delete"),
-            params={"id": created["id"]},
+            params={"id": created.id},
             headers=setup_data.user_admin["headers"],
             status=403,
         )
-        assert model.Session.query(IATIFile).get(created["id"]) is not None
+        assert model.Session.query(IATIFile).get(created.id) is not None
 
     # --- ERRORS / MESSAGES -----------------------------------------------------
 


### PR DESCRIPTION
This pull request adds a comprehensive test suite for the `iati_file_delete` API action, focusing on permissions, error handling, and correct execution. The new tests ensure that only authorized users can delete IATI files, and that appropriate error messages and status codes are returned for invalid or unauthorized requests.

**New test coverage for `iati_file_delete` action:**

* Added tests to verify that sysadmins and organization admins can successfully delete IATI files, including confirmation that the files are removed from the database.
* Implemented tests to ensure that editors, members, and admins of other organizations are denied permission to delete files, with proper status codes and database checks.

**Error handling and messaging:**

* Added tests for error scenarios, including missing file IDs (returns 403 Forbidden) and attempts to delete non-existent files (returns 404 Not Found with a descriptive error message).

fixes #44 