### PR TITLE
Refactor IATIFileTypes

### DIFF
--- a/ckanext/iati_generator/models/enums.py
+++ b/ckanext/iati_generator/models/enums.py
@@ -11,19 +11,27 @@ class IATIFileTypes(Enum):
     ORGANIZATION_BUDGET_FILE = 120
     ORGANIZATION_EXPENDITURE_FILE = 130
     ORGANIZATION_DOCUMENT_FILE = 140
+    FINAL_ORGANIZATION_FILE = 199
 
     # ------------------------------------------------------------------
     # ACTIVITY FILE TYPES
     # Always sync IatiMultiCsvConverter.csv_files
     # https://github.com/okfn/okfn_iati/blob/main/src/okfn_iati/multi_csv_converter.py#L56
     # ------------------------------------------------------------------
-    ACTIVITY_MAIN_FILE = 200
-    ACTIVITY_BUDGET_FILE = 210
-    ACTIVITY_EXPENDITURE_FILE = 220
-    ACTIVITY_DOCUMENT_FILE = 230
-    ACTIVITY_LOCATION_FILE = 240
-    ACTIVITY_SECTOR_FILE = 250
-    ACTIVITY_PARTNER_FILE = 260
-    ACTIVITY_RESULT_FILE = 270
-    ACTIVITY_TRANSACTION_FILE = 280
-    ACTIVITY_POLICY_FILE = 290
+    ACTIVITY_MAIN_FILE = 200                     # activities.csv
+    ACTIVITY_PARTICIPATING_ORGS_FILE = 210       # participating_orgs.csv
+    ACTIVITY_SECTORS_FILE = 220                  # sectors.csv
+    ACTIVITY_BUDGET_FILE = 230                   # budgets.csv
+    ACTIVITY_TRANSACTIONS_FILE = 240             # transactions.csv
+    ACTIVITY_TRANSACTION_SECTORS_FILE = 250      # transaction_sectors.csv
+    ACTIVITY_LOCATIONS_FILE = 260                # locations.csv
+    ACTIVITY_DOCUMENTS_FILE = 270                # documents.csv
+    ACTIVITY_RESULTS_FILE = 280                  # results.csv
+    ACTIVITY_INDICATORS_FILE = 290               # indicators.csv
+    ACTIVITY_INDICATOR_PERIODS_FILE = 300        # indicator_periods.csv
+    ACTIVITY_DATES_FILE = 310                    # activity_date.csv
+    ACTIVITY_CONTACT_INFO_FILE = 320             # contact_info.csv
+    ACTIVITY_CONDITIONS_FILE = 330               # conditions.csv
+    ACTIVITY_DESCRIPTIONS_FILE = 340             # descriptions.csv
+    ACTIVITY_COUNTRY_BUDGET_ITEMS_FILE = 350     # country_budget_items.csv
+    FINAL_ACTIVITY_FILE = 299


### PR DESCRIPTION
[Grabación de pantalla desde 2025-12-01 11-53-55.webm](https://github.com/user-attachments/assets/837ccff2-8a0f-4c58-98ff-6947a8c60f8e)


 Refactor IATIFileTypes enum to uncomment and define organization and activity file types

This pull request updates the `IATIFileTypes` enum in `enums.py` to expand and reorganize the available file types for both organization and activity data. The changes introduce a more comprehensive and clearly structured set of file type constants, grouped by theme and assigned unique integer values.

Enum expansion and reorganization:

* Added and assigned new integer values to organization-related file types, including `ORGANIZATION_BUDGET_FILE`, `ORGANIZATION_EXPENDITURE_FILE`, and `ORGANIZATION_DOCUMENT_FILE`, and grouped them under an "ORGANISATION FILE TYPES" section.
* Introduced a new "ACTIVITY FILE TYPES" section with file types such as `ACTIVITY_MAIN_FILE`, `ACTIVITY_BUDGET_FILE`, `ACTIVITY_EXPENDITURE_FILE`, and others, each with unique integer values.

fixes #63 