### PR TITLE
Automatically create activity.xml CKAN resource

### DIFF
--- a/ckanext/iati_generator/actions/iati.py
+++ b/ckanext/iati_generator/actions/iati.py
@@ -508,7 +508,9 @@ def iati_generate_activities_xml(context, data_dict):
     if not success:
         log.warning(f"Could not generate activity file for dataset {dataset['name']} ({dataset['id']})")
         # Is this the best way to handle this scenario?
-        raise toolkit.ValidationError("Activity.xml file could not be created probably due to missing mandatory files or corrupted data.")
+        raise toolkit.ValidationError(
+            "Activity.xml file could not be created probably due to missing mandatory files or corrupted data."
+        )
 
     activity_resource = None
     for res in dataset["resources"]:


### PR DESCRIPTION
This PR implements the `resource_create` or `resource_patch`  calls to create a CKAN resource after a successful execution of the IATI converters.

If the converter does not work, we return a `ValidationError` which is not ideal, but good enough to handle the workflow and create some error messages.