### PR TITLE
implementando url cortas iati

### DIFF
--- a/ckanext/iati_generator/assets/js/copy_link.js
+++ b/ckanext/iati_generator/assets/js/copy_link.js
@@ -1,0 +1,63 @@
+async function copyText(text) {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (e) {
+  }
+
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.top = "0";
+    ta.style.left = "-9999px";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+
+    ta.focus();
+    ta.select();
+    ta.setSelectionRange(0, ta.value.length);
+
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch (e) {
+    return false;
+  }
+}
+
+document.addEventListener(
+  "click",
+  async function (e) {
+    const btn = e.target.closest(".copy-link-btn");
+    if (!btn) return;
+
+    e.preventDefault();
+
+    const url = btn.dataset.url;
+    if (!url) {
+      console.error("Copy failed: data-url is empty");
+      return;
+    }
+
+    const ok = await copyText(url);
+
+    const li = btn.closest("li");
+    const message = li ? li.querySelector(".copy-message") : null;
+
+    if (ok) {
+      if (message) {
+        message.style.display = "inline";
+        setTimeout(() => {
+          message.style.display = "none";
+        }, 2000);
+      }
+    } else {
+      window.prompt("Copy link:", url);
+    }
+  },
+  true
+);

--- a/ckanext/iati_generator/assets/webassets.yml
+++ b/ckanext/iati_generator/assets/webassets.yml
@@ -1,14 +1,15 @@
-iati_generator-css:
-  filter: cssrewrite
-  output: iati_generator/%(version)s-main.css
-  contents:
-    - css/main.css
-
 iati_generator-js:
   filter: rjsmin
   output: iati_generator/%(version)s-main.js
   contents:
     - js/main.js
+    - js/copy_link.js
   extra:
     preload:
       - base/main
+
+iati_generator-css:
+  filter: cssrewrite
+  output: iati_generator/%(version)s-main.css
+  contents:
+    - css/main.css

--- a/ckanext/iati_generator/blueprint/public_iati.py
+++ b/ckanext/iati_generator/blueprint/public_iati.py
@@ -1,72 +1,57 @@
+import logging
 from flask import Blueprint, redirect
 from ckan.plugins import toolkit
-from ckan import model
-from ckanext.iati_generator.models.iati_files import IATIFile
 from ckanext.iati_generator.models.enums import IATIFileTypes
-from sqlalchemy import and_
+
+log = logging.getLogger(__name__)
 
 iati_public = Blueprint("iati_public", __name__, url_prefix="/iati")
 
 
-def _find_latest_resource_url(namespace, file_type):
-    """
-    Find the latest valid IATI file for a given namespace and file type.
+def _find_final_resource(dataset: dict, file_type_value: int):
+    for res in dataset.get("resources", []):
+        ft = res.get("iati_file_type")
 
-    :param namespace: The IATI namespace identifier.
-    :param file_type: The IATI file type (enum value).
-    :return: The resource URL, or None if no valid file is found.
-    """
+        if not ft:
+            for extra in res.get("extras", []):
+                if extra.get("key") == "iati_file_type":
+                    ft = extra.get("value")
+                    break
 
-    Session = model.Session
-    q = (
-        Session.query(IATIFile)
-        .filter(
-            and_(
-                IATIFile.namespace == namespace,
-                IATIFile.file_type == file_type,
-                IATIFile.is_valid.is_(True),
-                IATIFile.last_processed_success.isnot(None),
-            )
-        )
-        .order_by(IATIFile.last_processed_success.desc())
-        .first()
-    )
+        if not ft:
+            continue
 
-    # No valid file found
-    if not q:
-        return None
+        if str(ft).isdigit() and int(ft) == file_type_value:
+            return res.get("url")
 
-    # get full CKAN resource dict
-    context = {"ignore_auth": True}
-    try:
-        res_dict = toolkit.get_action("resource_show")(context, {"id": q.resource_id})
-        return res_dict.get("url")
-    except toolkit.ObjectNotFound:
-        # Resource was deleted, but IATIFile record still exists
-        return None
+    return None
 
 
-@iati_public.route("/<namespace>/organization.xml")
+@iati_public.route("/<namespace>/organisation.xml")
 def public_org(namespace):
-    """
-    Public endpoint to serve the latest valid organization XML file for a given namespace.
+    ctx = {"ignore_auth": True, "user": ""}
+    dataset = toolkit.get_action("iati_get_dataset_by_namespace")(ctx, {"namespace": namespace})
 
-    :param namespace: The namespace identifier for the IATI organization.
-    """
-    url = _find_latest_resource_url(namespace, IATIFileTypes.ORGANIZATION_MAIN_FILE.value)
+    if not dataset:
+        return toolkit.abort(404, f"No dataset found for namespace: {namespace}")
+
+    url = _find_final_resource(dataset, IATIFileTypes.FINAL_ORGANIZATION_FILE.value)
     if not url:
-        return toolkit.abort(404, f"No organization XML for namespace: {namespace}")
+        return toolkit.abort(404, f"No organisation.xml found for namespace: {namespace}")
+
     return redirect(url, code=302)
 
 
-@iati_public.route("/<namespace>/activities.xml")
+@iati_public.route("/<namespace>/activity.xml")
 def public_act(namespace):
-    """
-    Public endpoint to serve the latest valid activities XML file for a given namespace.
+    ctx = {"ignore_auth": True, "user": ""}
+    dataset = toolkit.get_action("iati_get_dataset_by_namespace")(ctx, {"namespace": namespace})
 
-    :param namespace: The namespace identifier for the IATI activities.
-    """
-    url = _find_latest_resource_url(namespace, IATIFileTypes.ACTIVITY_MAIN_FILE.value)
+    if not dataset:
+        return toolkit.abort(404, f"No dataset found for namespace: {namespace}")
+
+    url = _find_final_resource(dataset, IATIFileTypes.FINAL_ACTIVITY_FILE.value)
     if not url:
-        return toolkit.abort(404, f"No activities XML for namespace: {namespace}")
+        return toolkit.abort(404, f"No activity.xml found for namespace: {namespace}")
+
     return redirect(url, code=302)

--- a/ckanext/iati_generator/plugin.py
+++ b/ckanext/iati_generator/plugin.py
@@ -40,6 +40,7 @@ class IatiGeneratorPlugin(p.SingletonPlugin, DefaultTranslation):
             'iati_file_show': iati_actions.iati_file_show,
             'iati_generate_organisation_xml': iati_actions.iati_generate_organisation_xml,
             'iati_generate_activities_xml': iati_actions.iati_generate_activities_xml,
+            'iati_get_dataset_by_namespace': iati_actions.iati_get_dataset_by_namespace,
             # Chain to CKAN core actions
             # 'resource_create': resources_actions.resource_create,
             # 'resource_update': resources_actions.resource_update,
@@ -71,4 +72,5 @@ class IatiGeneratorPlugin(p.SingletonPlugin, DefaultTranslation):
         return {
             "iati_file_type": h.iati_file_types,
             "iati_namespaces": h.iati_namespaces,
+            "has_final_iati_resource": h.has_final_iati_resource,
         }

--- a/ckanext/iati_generator/templates/base.html
+++ b/ckanext/iati_generator/templates/base.html
@@ -3,9 +3,5 @@
 {% block styles %}
     {{ super() }}
     {% asset 'iati_generator/iati_generator-css' %}
-{% endblock %}
-
-{% block body_extras %}
-    {{ super() }}
     {% asset 'iati_generator/iati_generator-js' %}
 {% endblock %}

--- a/ckanext/iati_generator/templates/package/iati_files.html
+++ b/ckanext/iati_generator/templates/package/iati_files.html
@@ -165,4 +165,57 @@
       </p>
     </div>
   </section>
+
+  {% set has_final_activity = h.has_final_iati_resource(pkg_dict, "FINAL_ACTIVITY_FILE") %}
+  {% set has_final_org = h.has_final_iati_resource(pkg_dict, "FINAL_ORGANIZATION_FILE") %}
+
+  {% if pkg_dict and pkg_dict.get('iati_namespace') and (has_final_activity or has_final_org) %}
+
+    {% set act_url = h.url_for('iati_public.public_act', namespace=pkg_dict.get('iati_namespace'), _external=True) %}
+    {% set org_url = h.url_for('iati_public.public_org', namespace=pkg_dict.get('iati_namespace'), _external=True) %}
+
+    <h2 class="module-heading"><i class="fa fa-link"></i> {{ _("Public IATI links") }}</h2>
+    <div class="module-content">
+      <ul class="list-unstyled iati-public-links">
+        {% if has_final_activity %}
+        <li class="iati-public-link-item">
+          <i class="fa fa-external-link"></i>
+          <a href="{{ act_url }}" target="_blank" rel="noopener">
+            {{ _("View activity.xml") }}
+          </a>
+
+          <a href="javascript:void(0);"
+            class="copy-link-btn copy-url-link"
+            data-url="{{ act_url }}">
+            <i class="fa fa-copy"></i>
+          </a>
+
+          <span class="copy-message" style="display:none;">
+            {{ _("Link copied!") }}
+          </span>
+        </li>
+        {% endif %}
+
+        {% if has_final_org %}
+        <li class="iati-public-link-item">
+          <i class="fa fa-external-link"></i>
+          <a href="{{ org_url }}" target="_blank" rel="noopener">
+            {{ _("View organisation.xml") }}
+          </a>
+
+          <a href="javascript:void(0);"
+            class="copy-link-btn copy-url-link"
+            data-url="{{ org_url }}">
+            <i class="fa fa-copy"></i>
+          </a>
+
+          <span class="copy-message" style="display:none;">
+            {{ _("Link copied!") }}
+          </span>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
+
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
fixes https://github.com/okfn/ckan-bcie/issues/429

fixes https://github.com/okfn/ckanext-iati-generator/issues/96

**Exponiendo url de archivos XML generados para organisation.xml y activity.xml**

Se agrega también función para copiar el link 

<img width="1486" height="961" alt="image" src="https://github.com/user-attachments/assets/fc2a8493-d71c-4011-8adb-38173cf95c63" />
