### PR TITLE
Show IATI errors

### DIFF
--- a/ckanext/iati_generator/actions/iati.py
+++ b/ckanext/iati_generator/actions/iati.py
@@ -187,7 +187,9 @@ def iati_generate_organisation_xml(context, data_dict):
         # Use the CKAN ValidationError formar for errors
         validation_errors = {'Organizacion XML errors': converter.latest_errors}
         log.warning("Error when generating the organisation.xml file.")
-        raise toolkit.ValidationError("Error when generating the organisation.xml file.", errors=validation_errors)
+        raise toolkit.ValidationError(
+            {"error_org_xml": validation_errors}
+        )
 
     org_resource = None
     for res in dataset.get("resources", []):
@@ -282,8 +284,7 @@ def iati_generate_activities_xml(context, data_dict):
         validation_errors = {'Activity XML errors': converter.latest_errors}
         # Is this the best way to handle this scenario?
         raise toolkit.ValidationError(
-            "Activity.xml file could not be created probably due to missing mandatory files or corrupted data.",
-            errors=validation_errors
+            {"error_activity_xml": validation_errors}
         )
 
     activity_resource = None

--- a/ckanext/iati_generator/blueprint/admin.py
+++ b/ckanext/iati_generator/blueprint/admin.py
@@ -2,7 +2,6 @@ from ckan.plugins import toolkit
 from flask import Blueprint
 
 from ckanext.iati_generator import helpers as h
-from ckanext.iati_generator.decorators import require_sysadmin_user
 from ckanext.iati_generator.models.enums import IATIFileTypes
 
 iati_file_admin = Blueprint("iati_generator_admin_files", __name__)
@@ -53,13 +52,12 @@ def iati_files_index(package_id):
     )
 
 
-@iati_file_admin.route("/dataset/iati-files/<package_id>/errors")
 def iati_files_errors(package_id, errors):
-    """List IATI errors for the selected dataset while generating IATI XML file."""
-    toolkit.check_access("iati_generate_xml_files", {"user": toolkit.c.user}, {"package_id": package_id})
-
+    """Render the list of IATI errors for the selected dataset while generating IATI XML file."""
+    pkg_dict = toolkit.get_action('package_show')({}, {"id": package_id})
     return toolkit.render(
         "package/iati_errors.html", {
+            "pkg_dict": pkg_dict,
             "errors": errors,
             "iati_files_url": toolkit.url_for("iati_generator_admin_files.iati_files_index", package_id=package_id),
         },
@@ -80,17 +78,14 @@ def generate_iati_activity_file(package_id):
         toolkit.h.flash_error(
             toolkit._("There was an error generating the IATI file probably due to missing on wrong-formatted files.")
         )
+        return iati_files_errors(package_id, errors)
 
     try:
         res_url = toolkit.url_for("resource.read", package_type="dataset", id=resource["package_id"], resource_id=resource["id"])
     except toolkit.ObjectNotFound:
         errors = ['The dataset does not exist']
         toolkit.h.flash_error(toolkit._(f"The dataset with id {package_id} does not exist."))
-
-    if errors:
-        # redirect to errors page
-        redirect_url = toolkit.url_for("iati_generator_admin_files.iati_files_errors", package_id=package_id, errors=errors)
-        return toolkit.redirect_to(redirect_url)
+        return iati_files_errors(package_id, errors)
 
     msg = toolkit._(f"IATI File generated successfully, you can <a href={res_url}>click here to go to the resource.</a>")
     toolkit.h.flash_success(msg, allow_html=True)
@@ -113,16 +108,14 @@ def generate_iati_organisation_file(package_id):
         toolkit.h.flash_error(
             toolkit._("There was an error generating the IATI file probably due to missing on wrong-formatted files.")
         )
+        return iati_files_errors(package_id, errors)
 
     try:
         res_url = toolkit.url_for("resource.read", package_type="dataset", id=resource["package_id"], resource_id=resource["id"])
     except toolkit.ObjectNotFound:
         errors = ['The dataset does not exist']
         toolkit.h.flash_error(toolkit._(f"The dataset with id {package_id} does not exist."))
-
-    if errors:
-        redirect_url = toolkit.url_for("iati_generator_admin_files.iati_files_errors", package_id=package_id, errors=errors)
-        return toolkit.redirect_to(redirect_url)
+        return iati_files_errors(package_id, errors)
 
     msg = toolkit._(f"IATI File generated successfully, you can <a href={res_url}>click here to go to the resource.</a>")
     toolkit.h.flash_success(msg, allow_html=True)

--- a/ckanext/iati_generator/templates/package/iati_errors.html
+++ b/ckanext/iati_generator/templates/package/iati_errors.html
@@ -3,23 +3,26 @@
 {% block primary_content_inner %}
   <h1>Errores al compilar IATI</h1>
 
-        <div class="alert alert-warning">
-          <a href="{{ iati_files_url }}">Volver a archivos IATI</a>
-          <details class="missing-files-details">
-            <summary class="missing-files-summary">
-              Errores
-            </summary>
-            <div class="missing-files-category">
-              <ul class="missing-files-list">
-                {% for error in errors %}
-                  <li>
-                    {{ error }}
-                  </li>
-                {% endfor %}
-              </ul>
-            </div>
-          </details>
+    <p>
+      <a href="{{ iati_files_url }}">Volver a archivos IATI</a>
+    </p>
+    <div class="alert alert-warning">
+      
+      <details class="missing-files-details">
+        <summary class="missing-files-summary">
+          Errores
+        </summary>
+        <div class="missing-files-category">
+          <ul class="missing-files-list">
+            {% for k, error in errors.items() %}
+              <li>
+                {{ error }}
+              </li>
+            {% endfor %}
+          </ul>
         </div>
+      </details>
+    </div>
 
 {% endblock %}
 


### PR DESCRIPTION
fixes #79 (a initial version)

Implements https://github.com/okfn/okfn_iati/pull/38

We create a new view to display errors
We capture errors from the IATI library and display them in case of error.

Also:
 - Drop some `@require_sysadmin_user`

<img width="2191" height="895" alt="image" src="https://github.com/user-attachments/assets/b174f28f-6f99-49f3-9f5f-de6584d05655" />

In this picture we use a invalid date.
The IATI lib is not good showing the actual error. We still need to work for it