### PR TITLE
add get_iati_file_type_label

### DIFF
--- a/ckanext/iati_generator/assets/css/main.css
+++ b/ckanext/iati_generator/assets/css/main.css
@@ -91,3 +91,10 @@ details[open] summary {
 .missing-files-list {
     margin-top: 4px;
 }
+
+.iati-file-type-label {
+  margin-left: 8px;
+  color: #666;
+  font-size: 0.9em;
+  font-style: italic;
+}

--- a/ckanext/iati_generator/helpers.py
+++ b/ckanext/iati_generator/helpers.py
@@ -832,3 +832,18 @@ def normalize_iati_errors(error_dict: Any, package_id: Optional[str] = None) -> 
         "items": deduped,
         "raw": [raw_formatted],
     }
+
+
+def get_iati_file_type_label(value):
+    """
+    Converts an iati_file_type value to its human-readable label.
+    For example: '100' -> 'Organization Main File'
+    """
+    if not value:
+        return ''
+
+    for choice in iati_file_types():
+        if str(choice.get('value')) == str(value):
+            return choice.get('label', '')
+
+    return str(value)

--- a/ckanext/iati_generator/plugin.py
+++ b/ckanext/iati_generator/plugin.py
@@ -73,4 +73,5 @@ class IatiGeneratorPlugin(p.SingletonPlugin, DefaultTranslation):
             "iati_file_type": h.iati_file_types,
             "iati_namespaces": h.iati_namespaces,
             "has_final_iati_resource": h.has_final_iati_resource,
+            "get_iati_file_type_label": h.get_iati_file_type_label,
         }


### PR DESCRIPTION
related https://github.com/okfn/ckan-bcie/issues/486

se agrega `get_iati_file_type_label` y `css` que se quito del **bcie**